### PR TITLE
Can configure FFT

### DIFF
--- a/src/audio-loader.js
+++ b/src/audio-loader.js
@@ -1,10 +1,15 @@
 /* @flow */
 import * as THREE from 'three';
 
-export type AudioOptions = {
+type AudioOptions = {
   fftSize?: number;
   fftSmoothingTimeConstant?: number;
 }
+
+const DEFAULT_AUDIO_OPTIONS = {
+  fftSize: 2048,
+  fftSmoothingTimeConstant: 0.8,
+};
 
 export default class AudioLoader {
   static ctx = new (window.AudioContext || window.webkitAudioContext)();
@@ -25,7 +30,12 @@ export default class AudioLoader {
 
   _willPlay: Promise<any>;
 
-  constructor(rc: AudioOptions) {
+  constructor(_rc: AudioOptions) {
+    const rc = {
+      ...DEFAULT_AUDIO_OPTIONS,
+      ..._rc,
+    };
+
     this._ctx = AudioLoader.ctx;
     this._gain = this._ctx.createGain();
     this._analyser = this._ctx.createAnalyser();

--- a/src/audio-loader.js
+++ b/src/audio-loader.js
@@ -1,6 +1,11 @@
 /* @flow */
 import * as THREE from 'three';
 
+export type AudioOptions = {
+  fftSize?: number;
+  fftSmoothingTimeConstant?: number;
+}
+
 export default class AudioLoader {
   static ctx = new (window.AudioContext || window.webkitAudioContext)();
 
@@ -20,7 +25,7 @@ export default class AudioLoader {
 
   _willPlay: Promise<any>;
 
-  constructor() {
+  constructor(rc: AudioOptions) {
     this._ctx = AudioLoader.ctx;
     this._gain = this._ctx.createGain();
     this._analyser = this._ctx.createAnalyser();
@@ -28,8 +33,8 @@ export default class AudioLoader {
     this._gain.gain.value = 0;
     this._gain.connect(this._ctx.destination);
 
-    this._analyser.fftSize = 512;
-    this._analyser.smoothingTimeConstant = 0.4;
+    this._analyser.fftSize = rc.fftSize;
+    this._analyser.smoothingTimeConstant = rc.fftSmoothingTimeConstant;
     this._spectrumArray = new Uint8Array(this._analyser.frequencyBinCount);
     this._samplesArray = new Uint8Array(this._analyser.frequencyBinCount);
 
@@ -83,5 +88,19 @@ export default class AudioLoader {
 
   getVolume(): number {
     return this._spectrumArray.reduce((x, y) => x + y, 0) / this._spectrumArray.length;
+  }
+
+  setFftSize(fftSize: number): void {
+    this._analyser.fftSize = fftSize;
+    this._spectrumArray = new Uint8Array(this._analyser.frequencyBinCount);
+    this._samplesArray = new Uint8Array(this._analyser.frequencyBinCount);
+    this.spectrum.image.data = this._spectrumArray;
+    this.spectrum.image.width = this._analyser.frequencyBinCount;
+    this.samples.image.data = this._samplesArray;
+    this.samples.image.width = this._analyser.frequencyBinCount;
+  }
+
+  setFftSmoothingTimeConstant(fftSmoothingTimeConstant: number): void {
+    this._analyser.smoothingTimeConstant = fftSmoothingTimeConstant;
   }
 }

--- a/src/veda.js
+++ b/src/veda.js
@@ -1,6 +1,7 @@
 /* @flow */
 import * as THREE from 'three';
 import AudioLoader from './audio-loader';
+import type AudioOptions from './audio-loader';
 import MidiLoader from './midi-loader';
 import VideoLoader from './video-loader';
 import GifLoader from './gif-loader';
@@ -29,6 +30,7 @@ type VedaOptions = {
   frameskip?: number;
   vertexMode?: string;
   vertexCount?: number;
+  ...AudioOptions;
 }
 
 const DEFAULT_VEDA_OPTIONS = {
@@ -36,6 +38,8 @@ const DEFAULT_VEDA_OPTIONS = {
   frameskip: 1,
   vertexCount: 3000,
   vertexMode: 'TRIANGLES',
+  fftSize: 2048,
+  fftSmoothingTimeConstant: 0.8,
 };
 
 type RenderPassTarget = {
@@ -116,7 +120,7 @@ export default class Veda {
     // for TextureLoader & VideoLoader
     THREE.ImageUtils.crossOrigin = '*';
 
-    this._audioLoader = new AudioLoader();
+    this._audioLoader = new AudioLoader(rc);
     this._cameraLoader = new CameraLoader();
     this._gamepadLoader = new GamepadLoader();
     this._keyLoader = new KeyLoader();
@@ -157,6 +161,14 @@ export default class Veda {
 
   setVertexMode(mode: string): void {
     this._vertexMode = mode;
+  }
+
+  setFftSize(fftSize: number): void {
+    this._audioLoader.setFftSize(fftSize);
+  }
+
+  setFftSmoothingTimeConstant(fftSmoothingTimeConstant: number): void {
+    this._audioLoader.setFftSmoothingTimeConstant(fftSmoothingTimeConstant);
   }
 
   resetTime(): void {

--- a/src/veda.js
+++ b/src/veda.js
@@ -1,7 +1,6 @@
 /* @flow */
 import * as THREE from 'three';
 import AudioLoader from './audio-loader';
-import type AudioOptions from './audio-loader';
 import MidiLoader from './midi-loader';
 import VideoLoader from './video-loader';
 import GifLoader from './gif-loader';
@@ -30,7 +29,8 @@ type VedaOptions = {
   frameskip?: number;
   vertexMode?: string;
   vertexCount?: number;
-  ...AudioOptions;
+  fftSize?: number;
+  fftSmoothingTimeConstant?: number;
 }
 
 const DEFAULT_VEDA_OPTIONS = {
@@ -38,8 +38,6 @@ const DEFAULT_VEDA_OPTIONS = {
   frameskip: 1,
   vertexCount: 3000,
   vertexMode: 'TRIANGLES',
-  fftSize: 2048,
-  fftSmoothingTimeConstant: 0.8,
 };
 
 type RenderPassTarget = {


### PR DESCRIPTION
I set the default values back to WebAudio's defaults, is there really a need to differ?

I don't manage to PR *veda* before these changes are released, flow fails to compile, even if I replace `veda/node_modules/vedajs/lib` with this new one. Or do you know a way?