### PR TITLE
Upgrade threejs r100 -> r122 and enable use of GLSL3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ lib/
 node_modules/
 yarn-error.log
 npm-debug.log
+index.js

--- a/package.json
+++ b/package.json
@@ -1,57 +1,54 @@
 {
-  "name": "vedajs",
-  "description": "Shader Art Framework",
-  "version": "0.16.0",
-  "author": "fand <fand.gmork@gmail.com>",
-  "bugs": "https://github.com/fand/vedajs/issues",
-  "dependencies": {
-    "@fand/gifuct-js": "^1.0.0",
-    "is-video": "^1.0.1",
-    "three": "^0.100.0",
-    "three-mtl-loader": "^1.0.2",
-    "three-obj-loader": "^1.1.3"
-  },
-  "devDependencies": {
-    "@types/three": "0.93.15",
-    "@types/webmidi": "2.0.2",
-    "husky": "1.3.1",
-    "lint-staged": "8.1.0",
-    "npm-run-all": "4.1.5",
-    "prettier": "1.15.3",
-    "tslint": "6.1.0",
-    "tslint-config-prettier": "1.17.0",
-    "tslint-plugin-prettier": "2.0.1",
-    "typescript": "3.2.4"
-  },
-  "files": [
-    "README.md",
-    "package.json",
-    "lib"
-  ],
-  "homepage": "https://veda.gl/vedajs",
-  "keywords": [
-    "GLSL",
-    "Shader",
-    "WebGL"
-  ],
-  "license": "MIT",
-  "main": "lib/index.js",
-  "repository": "https://github.com/fand/vedajs",
-  "scripts": {
-    "build": "tsc -d",
-    "precommit": "lint-staged",
-    "prepublish": "npm run test && npm run build",
-    "test": "tslint -c tslint.json 'src/**/*.ts'",
-    "format": "tslint -c tslint.json --fix 'src/**/*.ts'",
-    "watch": "tsc -w"
-  },
-  "types": "lib/index.d.ts",
-  "lint-staged": {
-    "*.{ts}": [
-      "tslint --fix"
+    "name": "vedajs",
+    "description": "Shader Art Framework",
+    "version": "0.16.0",
+    "author": "fand <fand.gmork@gmail.com>",
+    "bugs": "https://github.com/fand/vedajs/issues",
+    "dependencies": {
+        "@fand/gifuct-js": "^1.0.0",
+        "is-video": "^1.0.1",
+        "three": "^0.122.0"
+    },
+    "devDependencies": {
+        "@types/webmidi": "2.0.2",
+        "husky": "1.3.1",
+        "lint-staged": "8.1.0",
+        "npm-run-all": "4.1.5",
+        "prettier": "1.15.3",
+        "tslint": "6.1.0",
+        "tslint-config-prettier": "1.17.0",
+        "tslint-plugin-prettier": "2.0.1",
+        "typescript": "3.9.3"
+    },
+    "files": [
+        "README.md",
+        "package.json",
+        "lib"
     ],
-    "*.{md}": [
-      "prettier --write"
-    ]
-  }
+    "homepage": "https://veda.gl/vedajs",
+    "keywords": [
+        "GLSL",
+        "Shader",
+        "WebGL"
+    ],
+    "license": "MIT",
+    "main": "lib/index.js",
+    "repository": "https://github.com/fand/vedajs",
+    "scripts": {
+        "build": "tsc -d",
+        "precommit": "lint-staged",
+        "prepublish": "npm run test && npm run build",
+        "test": "tslint -c tslint.json 'src/**/*.ts'",
+        "format": "tslint -c tslint.json --fix 'src/**/*.ts'",
+        "watch": "tsc -w"
+    },
+    "types": "lib/index.d.ts",
+    "lint-staged": {
+        "*.{ts}": [
+            "tslint --fix"
+        ],
+        "*.{md}": [
+            "prettier --write"
+        ]
+    }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "WebGL"
     ],
     "license": "MIT",
-    "main": "lib/index.js",
+    "main": "index.js",
     "repository": "https://github.com/fand/vedajs",
     "scripts": {
         "build": "run-p build:rollup",

--- a/package.json
+++ b/package.json
@@ -6,15 +6,19 @@
     "bugs": "https://github.com/fand/vedajs/issues",
     "dependencies": {
         "@fand/gifuct-js": "^1.0.0",
-        "is-video": "^1.0.1",
         "three": "^0.122.0"
     },
     "devDependencies": {
+        "@rollup/plugin-commonjs": "^16.0.0",
+        "@rollup/plugin-node-resolve": "^10.0.0",
+        "@rollup/plugin-typescript": "^6.1.0",
+        "@types/node": "^14.14.7",
         "@types/webmidi": "2.0.2",
         "husky": "1.3.1",
         "lint-staged": "8.1.0",
         "npm-run-all": "4.1.5",
         "prettier": "1.15.3",
+        "rollup": "^2.33.2",
         "tslint": "6.1.0",
         "tslint-config-prettier": "1.17.0",
         "tslint-plugin-prettier": "2.0.1",
@@ -35,7 +39,8 @@
     "main": "lib/index.js",
     "repository": "https://github.com/fand/vedajs",
     "scripts": {
-        "build": "tsc -d",
+        "build": "run-p build:rollup",
+        "build:rollup": "rollup -c",
         "precommit": "lint-staged",
         "prepublish": "npm run test && npm run build",
         "test": "tslint -c tslint.json 'src/**/*.ts'",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
     ],
     "license": "MIT",
     "main": "index.js",
+    "module": "lib/index.js",
     "repository": "https://github.com/fand/vedajs",
     "scripts": {
-        "build": "run-p build:rollup",
+        "build": "run-p build:ts build:rollup",
+        "build:ts": "tsc -d",
         "build:rollup": "rollup -c",
         "precommit": "lint-staged",
         "prepublish": "npm run test && npm run build",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,13 +8,7 @@ export default {
         dir: '.',
         format: 'cjs',
         exports: 'named',
+        outro: `module.exports.default = module.exports;`,
     },
-    plugins: [
-        typescript({
-            module: 'es6',
-            target: 'es6',
-        }),
-        nodeResolve(),
-        commonjs(),
-    ],
+    plugins: [typescript({}), nodeResolve(), commonjs()],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,7 @@ import commonjs from '@rollup/plugin-commonjs';
 export default {
     input: 'src/index.ts',
     output: {
-        dir: './lib',
+        dir: '.',
         format: 'cjs',
         exports: 'named',
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ export default {
         dir: '.',
         format: 'cjs',
         exports: 'named',
-        outro: `module.exports.default = module.exports;`,
+        //outro: `module.exports.default = module.exports;`,
     },
     plugins: [typescript({}), nodeResolve(), commonjs()],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,20 @@
+import typescript from '@rollup/plugin-typescript';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+
+export default {
+    input: 'src/index.ts',
+    output: {
+        dir: './lib',
+        format: 'cjs',
+        exports: 'named',
+    },
+    plugins: [
+        typescript({
+            module: 'es6',
+            target: 'es6',
+        }),
+        nodeResolve(),
+        commonjs(),
+    ],
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,15 +37,13 @@ void main() {
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 }`;
 
-export const DEFAULT_FRAGMENT_SHADER = `#version 300 es
+export const DEFAULT_FRAGMENT_SHADER = `
 precision mediump float;
-out vec4 FragColor;
-
 varying vec2 vUv;
 varying float vObjectId;
 varying vec4 v_color;
 void main() {
-    FragColor = v_color;
+    gl_FragColor = v_color;
 }
 `;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,20 +1,52 @@
 export const DEFAULT_VERTEX_SHADER = `
-precision mediump float;
 varying vec2 vUv;
 varying float vObjectId;
 varying vec4 v_color;
+invariant gl_Position;
+
 void main() {
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 }
 `;
 
-export const DEFAULT_FRAGMENT_SHADER = `
+export const DEFAULT_3_VERTEX_SHADER = `#version 300 es
+#define attribute in
+#define varying out
+#define texture2D texture
+precision highp float;
+precision highp int;
+invariant gl_Position;
+
+uniform mat4 modelMatrix;
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+uniform mat4 viewMatrix;
+uniform mat3 normalMatrix;
+uniform vec3 cameraPosition;
+uniform bool isOrthographic;
+
+attribute vec3 position;
+attribute vec3 normal;
+attribute vec2 uv;
+
+
+varying vec2 vUv;
+varying float vObjectId;
+varying vec4 v_color;
+
+void main() {
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}`;
+
+export const DEFAULT_FRAGMENT_SHADER = `#version 300 es
 precision mediump float;
+out vec4 FragColor;
+
 varying vec2 vUv;
 varying float vObjectId;
 varying vec4 v_color;
 void main() {
-    gl_FragColor = v_color;
+    FragColor = v_color;
 }
 `;
 
@@ -83,6 +115,7 @@ export interface IPass {
     WIDTH?: string;
     HEIGHT?: string;
     BLEND?: BlendMode;
+    GLSL3?: boolean;
 }
 
 export type BlendMode = 'NO' | 'NORMAL' | 'ADD' | 'SUB' | 'MUL';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,6 @@ export const DEFAULT_VERTEX_SHADER = `
 varying vec2 vUv;
 varying float vObjectId;
 varying vec4 v_color;
-invariant gl_Position;
 
 void main() {
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);

--- a/src/is-video.ts
+++ b/src/is-video.ts
@@ -1,0 +1,45 @@
+import * as path from 'path';
+
+const videoExtensions = [
+    '3g2',
+    '3gp',
+    'aaf',
+    'asf',
+    'avchd',
+    'avi',
+    'drc',
+    'flv',
+    'm2v',
+    'm4p',
+    'm4v',
+    'mkv',
+    'mng',
+    'mov',
+    'mp2',
+    'mp4',
+    'mpe',
+    'mpeg',
+    'mpg',
+    'mpv',
+    'mxf',
+    'nsv',
+    'ogg',
+    'ogv',
+    'qt',
+    'rm',
+    'rmvb',
+    'roq',
+    'svi',
+    'vob',
+    'webm',
+    'wmv',
+    'yuv',
+];
+
+export default function(filepath: string) {
+    const ext = path
+        .extname(filepath)
+        .slice(1)
+        .toLowerCase();
+    return videoExtensions.includes(ext);
+}

--- a/src/sound-renderer.ts
+++ b/src/sound-renderer.ts
@@ -158,12 +158,9 @@ export default class SoundRenderer {
 
             // Update uniform
             this.soundUniforms.iBlockOffset.value = off / this.ctx.sampleRate;
-            this.renderer.render(
-                this.scene as any,
-                this.camera as any,
-                this.target,
-                true,
-            );
+            this.renderer.setRenderTarget(this.target);
+            this.renderer.render(this.scene as any, this.camera as any);
+            this.renderer.setRenderTarget(null);
 
             // Get pixels
             const pixels = new Uint8Array(PIXELS * 4);

--- a/src/veda.ts
+++ b/src/veda.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils';
 import AudioLoader from './audio-loader';
 import CameraLoader from './camera-loader';
 import GamepadLoader from './gamepad-loader';
@@ -9,10 +10,7 @@ import ModelLoader from './model-loader';
 import SoundLoader from './sound-loader';
 import SoundRenderer from './sound-renderer';
 import VideoLoader from './video-loader';
-import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils';
-
-declare var require: any;
-const isVideo = require('is-video');
+import isVideo from './is-video';
 
 import {
     DEFAULT_FRAGMENT_SHADER,
@@ -24,6 +22,7 @@ import {
     IPass,
     IShader,
     BlendMode,
+    DEFAULT_3_VERTEX_SHADER,
 } from './constants';
 
 interface IRenderPassTarget {
@@ -295,11 +294,21 @@ export default class Veda {
         } else {
             // Create plane
             const geometry = new THREE.PlaneGeometry(2, 2);
-            const material = new THREE.ShaderMaterial({
-                vertexShader: DEFAULT_VERTEX_SHADER,
-                fragmentShader: pass.fs,
-                uniforms: this.uniforms,
-            });
+            let material: THREE.ShaderMaterial;
+            if (!!pass.GLSL3) {
+                material = new THREE.RawShaderMaterial({
+                    vertexShader: DEFAULT_3_VERTEX_SHADER,
+                    fragmentShader: pass.fs,
+                    uniforms: this.uniforms,
+                });
+            } else {
+                material = new THREE.ShaderMaterial({
+                    vertexShader: DEFAULT_VERTEX_SHADER,
+                    fragmentShader: pass.fs,
+                    uniforms: this.uniforms,
+                });
+            }
+
             material.extensions = {
                 derivatives: true,
                 drawBuffers: true,
@@ -382,11 +391,21 @@ export default class Veda {
         } else {
             // Create plane
             const geometry = obj.geometry;
-            const material = new THREE.ShaderMaterial({
-                vertexShader: DEFAULT_VERTEX_SHADER,
-                fragmentShader: pass.fs,
-                uniforms: this.uniforms,
-            });
+            let material: THREE.ShaderMaterial;
+            if (!!pass.GLSL3) {
+                material = new THREE.RawShaderMaterial({
+                    vertexShader: DEFAULT_3_VERTEX_SHADER,
+                    fragmentShader: pass.fs,
+                    uniforms: this.uniforms,
+                });
+            } else {
+                material = new THREE.ShaderMaterial({
+                    vertexShader: DEFAULT_VERTEX_SHADER,
+                    fragmentShader: pass.fs,
+                    uniforms: this.uniforms,
+                });
+            }
+
             material.extensions = {
                 derivatives: true,
                 drawBuffers: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
   },
   "include": ["src"],
   "exclude": ["examples"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2015",
-    "module": "commonjs",
+    "target": "ES6",
+    "module": "ES6",
     "baseUrl": ".",
     "rootDir": "./src",
     "lib": ["es2015", "es2017", "dom"],
@@ -14,8 +14,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
-    "declaration": true,
-    "declarationMap": true,
   },
   "include": ["src"],
   "exclude": ["examples"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "target": "es2015",
     "module": "commonjs",
+    "baseUrl": ".",
+    "rootDir": "./src",
     "lib": ["es2015", "es2017", "dom"],
     "sourceMap": true,
     "outDir": "lib",
@@ -13,6 +15,6 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node"
   },
-  "include": ["src", "typings"],
+  "include": ["src"],
   "exclude": ["examples"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2015",
     "module": "commonjs",
-    "lib": ["es2015", "dom"],
+    "lib": ["es2015", "es2017", "dom"],
     "sourceMap": true,
     "outDir": "lib",
     "removeComments": true,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'is-video' {
-    export default function isVideo(url: string): boolean;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,12 +37,76 @@
     log-update "^2.3.0"
     strip-ansi "^3.0.1"
 
+"@rollup/plugin-commonjs@^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-16.0.0.tgz#169004d56cd0f0a1d0f35915d31a036b0efe281f"
+  integrity sha512-LuNyypCP3msCGVQJ7ki8PqYdpjfEkE/xtFa5DqlF+7IBD0JsfMZ87C58heSwIMint58sAUZbt3ITqOmdQv/dXw==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    commondir "^1.0.1"
+    estree-walker "^2.0.1"
+    glob "^7.1.6"
+    is-reference "^1.2.1"
+    magic-string "^0.25.7"
+    resolve "^1.17.0"
+
+"@rollup/plugin-node-resolve@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-10.0.0.tgz#44064a2b98df7530e66acf8941ff262fc9b4ead8"
+  integrity sha512-sNijGta8fqzwA1VwUEtTvWCx2E7qC70NMsDh4ZG13byAXYigBNZMxALhKUSycBks5gupJdq0lFrKumFrRZ8H3A==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.17.0"
+
+"@rollup/plugin-typescript@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-6.1.0.tgz#289e7f0ea12fd659bd13ad59dda73b9055538b83"
+  integrity sha512-hJxaiE6WyNOsK+fZpbFh9CUijZYqPQuAOWO5khaGTUkM8DYNNyA2TDlgamecE+qLOG1G1+CwbWMAx3rbqpp6xQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    resolve "^1.17.0"
+
+"@rollup/pluginutils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
   integrity sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==
   dependencies:
     any-observable "^0.3.0"
+
+"@types/estree@*":
+  version "0.0.45"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
+  integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
+
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/node@*", "@types/node@^14.14.7":
+  version "14.14.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.7.tgz#8ea1e8f8eae2430cf440564b98c6dfce1ec5945d"
+  integrity sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/webmidi@2.0.2":
   version "2.0.2"
@@ -197,6 +261,11 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
   integrity sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=
 
+builtin-modules@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
+  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -311,6 +380,11 @@ commander@^2.12.1, commander@^2.14.1, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
@@ -391,6 +465,11 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
+
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 define-properties@^1.1.2:
   version "1.1.3"
@@ -495,6 +574,16 @@ esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+
+estree-walker@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.1.tgz#f8e030fb21cefa183b44b7ad516b747434e7a3e0"
+  integrity sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -615,6 +704,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@~2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
+  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
 function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -655,6 +749,18 @@ glob@^7.0.3, glob@^7.1.1, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -824,6 +930,13 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-core-module@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.1.0.tgz#a4cc031d9b1aca63eecbd18a650e13cb4eeab946"
+  integrity sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==
+  dependencies:
+    has "^1.0.3"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -902,6 +1015,11 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -952,6 +1070,13 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
+is-reference@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
+
 is-regex@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -975,13 +1100,6 @@ is-symbol@^1.0.2:
   integrity sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==
   dependencies:
     has-symbols "^1.0.0"
-
-is-video@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-video/-/is-video-1.0.1.tgz#7bc67760b0103d402bc1f10bb542f16a3687773b"
-  integrity sha1-e8Z3YLAQPUArwfELtULxajaHdzs=
-  dependencies:
-    video-extensions "^1.0.0"
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -1215,6 +1333,13 @@ log-update@^2.3.0:
     ansi-escapes "^3.0.0"
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
+
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 map-cache@^0.2.2:
   version "0.2.2"
@@ -1502,6 +1627,11 @@ path-type@^3.0.0:
   dependencies:
     pify "^3.0.0"
 
+picomatch@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
 pidtree@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.0.tgz#f6fada10fccc9f99bf50e90d0b23d72c9ebc2e6b"
@@ -1615,6 +1745,14 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
+resolve@^1.17.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
+    path-parse "^1.0.6"
+
 resolve@^1.3.2:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.9.0.tgz#a14c6fdfa8f92a7df1d996cb7105fa744658ea06"
@@ -1641,6 +1779,13 @@ rimraf@^2.2.8:
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
+
+rollup@^2.33.2:
+  version "2.33.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.33.2.tgz#c4c76cd405a7605e6ebe90976398c46d4c2ea166"
+  integrity sha512-QPQ6/fWCrzHtSXkI269rhKaC7qXGghYBwXU04b1JsDZ6ibZa3DJ9D1SFAYRMgx1inDg0DaTbb3N4Z1NK/r3fhw==
+  optionalDependencies:
+    fsevents "~2.1.2"
 
 run-node@^1.0.0:
   version "1.0.0"
@@ -1785,6 +1930,11 @@ source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -2038,11 +2188,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-video-extensions@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/video-extensions/-/video-extensions-1.1.0.tgz#eaa86b45f29a853c2b873e9d8e23b513712997d6"
-  integrity sha1-6qhrRfKahTwrhz6djiO1E3Epl9Y=
 
 which@^1.2.10, which@^1.2.9:
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,11 +44,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@types/three@0.93.15":
-  version "0.93.15"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.93.15.tgz#8fbb4ee8c0648372a305469d16e37d0a939f91c3"
-  integrity sha512-AE9kgUDqMrInTfMYzZ8NqgBMzUgHvv+JwUQxCmlWZOfs+TCJDn7CVcvcOyftiUO3MAH1bddwaK0ZvZ/9M1rO5A==
-
 "@types/webmidi@2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/webmidi/-/webmidi-2.0.2.tgz#0466cf747aaed2b914a1e2564635bbda217cb256"
@@ -1923,27 +1918,10 @@ symbol-observable@^1.1.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
-three-mtl-loader@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/three-mtl-loader/-/three-mtl-loader-1.0.2.tgz#d0060f1afb8bc2c166ea56cebad250d73da18563"
-  integrity sha512-GqDrWC5rbi+0/gp999S4lpCSHroBEfe9NqmH165orG0QhXeknL/eSNVMJUWBNgg2sBW7vlqVNWD/P0kdHeGC9g==
-  dependencies:
-    three "^0.87.1"
-
-three-obj-loader@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/three-obj-loader/-/three-obj-loader-1.1.3.tgz#4d540a256fcf2a59a6c6e0cd51a623efd76fd87d"
-  integrity sha512-usuOOTAqeM7J7dyae/I9ltFnfy1g47Hsr3byTvBTeH9LYz5vb2i8rLd2Hi1HEr0MbB5H4p9YrqFaDGcijXEVNw==
-
-three@^0.100.0:
-  version "0.100.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.100.0.tgz#262841c0b7d88ebd62af73f28d9f578963b3aa00"
-  integrity sha512-/lN2rdE1OqIwJr4/HcSaOisiCY0uVA0sqPpbCG5nil2uICEdS0LfGwSVYTtZDsIpR76r3++h5H3Hzg5D+SJBRQ==
-
-three@^0.87.1:
-  version "0.87.1"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.87.1.tgz#466a34edc4543459ced9b9d7d276b65216fe2ba8"
-  integrity sha1-Rmo07cRUNFnO2bnX0na2Uhb+K6g=
+three@^0.122.0:
+  version "0.122.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.122.0.tgz#bd9ed8a8820074856e8ba7b63fe0a65176e01aeb"
+  integrity sha512-bgYMo0WdaQhf7DhLE8OSNN/rVFO5J4K1A2VeeKqoV4MjjuHjfCP6xLpg8Xedhns7NlEnN3sZ6VJROq19Qyl6Sg==
 
 to-object-path@^0.3.0:
   version "0.3.0"
@@ -2020,10 +1998,10 @@ tsutils@^2.29.0:
   dependencies:
     tslib "^1.8.1"
 
-typescript@3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.4.tgz#c585cb952912263d915b462726ce244ba510ef3d"
-  integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+typescript@3.9.3:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
+  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Motivation: want to use integer bit shift to generate random numbers -> requires GLSL3 -> requires WebGL2

- Removed dependency on 'is-video' and '@types/three'.
- New bundling using rollup helps to deal with three/examples/jsm/* stuff which uses ES Modules whereas atom expects CommonJS modules. vedajs still uses cjs.

This needs to be used in conjunction with another pull request on veda for it to work properly I assume, but shouldn't break any existing shaders afaik.
